### PR TITLE
Release Hoverfly for Linux/ARM64

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -8,7 +8,7 @@ HF_BUILD_DIR=${DIR}/core/cmd/hoverfly
 HCTL_BUILD_DIR=${DIR}/hoverctl
 LICENSE=${DIR}/LICENSE
 GOX="${GOPATH}/bin/gox"
-declare -a OSARCH_LIST=("darwin/amd64" "windows/amd64" "windows/386" "linux/amd64" "linux/386")
+declare -a OSARCH_LIST=("darwin/amd64" "windows/amd64" "windows/386" "linux/amd64" "linux/386" "linux/arm64")
 
 for OSARCH in "${OSARCH_LIST[@]}"; do
   SUFFIX=$(echo ${OSARCH//darwin/OSX} | tr / _ )


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** Following file has been modified :

build-release.sh: Added linux/arm64 to the OSARCH_LIST to release hoverfly for ARM64.

**2. Testing Detail:** After adding linux/arm64 to the OSARCH-LIST, I triggered the build to circleci. Please find my jobs [here](https://app.circleci.com/pipelines/github/SmilePleasee/hoverfly/8/workflows/324b373a-afb4-4406-bc85-e70b08819ad0/jobs/16/steps). I have added 'store-artifacts' to the job, and downloaded hoverfly arm64 zip file locally and checked it via file command. It has aarch64 binaries. Below is the output:
~~~
x64_server@x_server_embedded:~/FAAS_Project/rahul$ file hoverfly
hoverfly: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
x64_server@x_server_embedded:~/FAAS_Project/rahul$ file hoverctl
hoverctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
~~~

**3. PR Description:** Here is my commit message :

Added "linux/arm64" to the OSARCH_LIST in the build-release.sh file.

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Reviewer:** Pruthvi Teja Reddy & Shobhit Parashari

**Thanks
Rahul Aggarwal**